### PR TITLE
Revert "IPFS API tutorial: Fix typo (#2)"

### DIFF
--- a/ipfs-go-client/app/main.go
+++ b/ipfs-go-client/app/main.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"fmt"
+	"time"
+
+	"io"
+	"strings"
 
 	shell "github.com/ipfs/go-ipfs-api"
 )
@@ -70,7 +74,7 @@ func main() {
 		fmt.Println("Error downloading file:", err.Error())
 		return
 	}
-	fmt.Println("File downloaded")
+	fmt.Println("File donwloaded")
 
 	separator()
 

--- a/ipfs-go-client/solution/main.go
+++ b/ipfs-go-client/solution/main.go
@@ -90,7 +90,7 @@ func main() {
 		fmt.Println("Error downloading file:", err.Error())
 		return
 	}
-	fmt.Println("File downloaded")
+	fmt.Println("File donwloaded")
 
 	separator()
 


### PR DESCRIPTION
This reverts commit 916eb5f82c4f0cdd58ba8f7f70012514361b5035.